### PR TITLE
Fix bit manipulation overflow, VCD ID overflow, and corner tile detection

### DIFF
--- a/crates/aegis-ip/src/tile_bits.rs
+++ b/crates/aegis-ip/src/tile_bits.rs
@@ -94,7 +94,7 @@ pub fn set_bit(bits: &mut [u8], offset: usize) {
 /// Clear bits at a given offset and width.
 pub fn clear_bits(bits: &mut [u8], offset: usize, width: usize) {
     for i in 0..width {
-        bits[(offset + i) / 8] &= !(1 << ((offset + i) % 8));
+        bits[(offset + i) / 8] &= !(1u8 << ((offset + i) % 8));
     }
 }
 
@@ -102,7 +102,7 @@ pub fn clear_bits(bits: &mut [u8], offset: usize, width: usize) {
 pub fn write_bits(bits: &mut [u8], offset: usize, value: u64, width: usize) {
     clear_bits(bits, offset, width);
     for i in 0..width {
-        if value & (1 << i) != 0 {
+        if value & (1u64 << i) != 0 {
             set_bit(bits, offset + i);
         }
     }
@@ -115,7 +115,7 @@ pub fn read_bits(bits: &[u8], offset: usize, width: usize) -> u64 {
         let byte_idx = (offset + i) / 8;
         let bit_idx = (offset + i) % 8;
         if byte_idx < bits.len() && bits[byte_idx] & (1 << bit_idx) != 0 {
-            val |= 1 << i;
+            val |= 1u64 << i;
         }
     }
     val

--- a/crates/aegis-sim/src/lib.rs
+++ b/crates/aegis-sim/src/lib.rs
@@ -345,7 +345,11 @@ impl VcdWriter {
 
     pub fn add_signal(&mut self, name: &str) -> char {
         let id = self.next_id;
-        self.next_id = (self.next_id as u8 + 1) as char;
+        if id < '~' {
+            self.next_id = (self.next_id as u8 + 1) as char;
+        } else {
+            panic!("VcdWriter: too many signals for single-character VCD IDs");
+        }
         self.buf
             .push_str(&format!("$var wire 1 {id} {name} $end\n"));
         self.signals.push((name.to_string(), id));

--- a/nextpnr-aegis/aegis.cc
+++ b/nextpnr-aegis/aegis.cc
@@ -238,7 +238,7 @@ private:
             tw.track_w.push_back(ctx->addWire(h.xy_id(x, y, ctx->idf("W%d", t)),
                                               ctx->id("ROUTING"), x, y));
           }
-        } else if (x != y) {
+        } else if (!(x == 0 && y == 0) && !(x == W - 1 && y == 0) && !(x == 0 && y == H - 1) && !(x == W - 1 && y == H - 1)) {
           // IO tile wires
           for (int z = 0; z < 2; z++) {
             tw.pad.push_back(ctx->addWire(h.xy_id(x, y, ctx->idf("PAD%d", z)),
@@ -269,7 +269,9 @@ private:
     for (int y = 0; y < H; y++) {
       for (int x = 0; x < W; x++) {
         if (is_io(x, y)) {
-          if (x == y)
+          // Skip corner tiles — they have no IO pads
+          if ((x == 0 && y == 0) || (x == W - 1 && y == 0) ||
+              (x == 0 && y == H - 1) || (x == W - 1 && y == H - 1))
             continue;
           add_io_bels(x, y);
         } else {
@@ -320,7 +322,8 @@ private:
     for (int y = 0; y < H; y++) {
       for (int x = 0; x < W; x++) {
         if (is_io(x, y)) {
-          if (x != y)
+          if (!((x == 0 && y == 0) || (x == W - 1 && y == 0) ||
+                (x == 0 && y == H - 1) || (x == W - 1 && y == H - 1)))
             add_io_pips(x, y);
         } else {
           add_logic_pips(x, y);


### PR DESCRIPTION
## Summary

- **Fix integer overflow in bitstream read/write** (`crates/aegis-ip/src/tile_bits.rs`) — `1 << i` defaults to `i32` in Rust, which panics in debug mode when `i >= 32`. Changed to `1u64 << i` and `1u8 <<` for correct types.

- **Fix VCD writer signal ID overflow** (`crates/aegis-sim/src/lib.rs`) — `next_id` wraps past `'~'` into invalid characters. Added guard to panic with clear message.

- **Fix incorrect corner tile detection in nextpnr** (`nextpnr-aegis/aegis.cc`) — `x == y` only works for square grids. Fixed to explicitly check all four corners.

## Test plan

- [ ] Verify existing tile_bits_tests.rs still pass
- [ ] Test with tracks=4 for 102+ bit configs
- [ ] Run blinky sim on non-square fabric (e.g. 4x6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)